### PR TITLE
Divide out the build from test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - run: ./scripts/artefacts/build.sh unit
-      - run: ./scripts/artefacts/build.sh package
+      - run: ./scripts/test/unit.sh go
+      - run: ./scripts/test/unit.sh clean
+      #- run: ./scripts/artefacts/build.sh package
       # - uses: actions/upload-artifact@v1
       #   with:
       #     name: native-go-web

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: ./scripts/test/unit.sh go
-      - run: ./scripts/test/unit.sh clean
       #- run: ./scripts/artefacts/build.sh package
       # - uses: actions/upload-artifact@v1
       #   with:

--- a/build/package/artefacts/Dockerfile
+++ b/build/package/artefacts/Dockerfile
@@ -28,11 +28,11 @@ COPY ./web/reactjs/src /opt/src
 
 RUN npm install && npm audit fix && npm run build
 
-# Go test phase
+# Go build phase
 # Utilising a go packaging tool github.com/GeertJohan/go.rice
 # the web artefacts is packaged into a file name rice-box.go.
 # Go builder then generates a version for linux platform.
-FROM golang:1.13.3 as gotest
+FROM golang:1.13.3 as gobuild
 
 WORKDIR /opt
 
@@ -43,28 +43,6 @@ COPY --from=nodebuild /opt/public ./web
 
 COPY ./go.mod ./go.mod
 COPY ./go.sum ./go.sum
-
-RUN go get github.com/GeertJohan/go.rice/rice && \
-    ./build/go-rice.sh && \
-    go mod download && \
-    go test -v hls-devkit/hlsadmin/internal/usermgmt && \
-    go test -v hls-devkit/hlsadmin/cmd/hlsadmin/cli
-
-# Go build phase
-# Utilising a go packaging tool github.com/GeertJohan/go.rice
-# the web artefacts is packaged into a file name rice-box.go.
-# Go builder then generates a version for linux platform.
-FROM golang:1.13.3 as gobuild
-
-WORKDIR /opt
-
-COPY --from=gotest /opt/cmd ./cmd
-COPY --from=gotest /opt/internal ./internal
-COPY --from=gotest /opt/build/go-rice.sh ./build/go-rice.sh
-COPY --from=gotest /opt/web ./web
-
-COPY --from=gotest /opt/go.mod ./go.mod
-COPY --from=gotest /opt/go.sum ./go.sum
 
 RUN go get github.com/GeertJohan/go.rice/rice && \
     ./build/go-rice.sh && \

--- a/build/package/test/unit/go.dockerfile
+++ b/build/package/test/unit/go.dockerfile
@@ -1,0 +1,27 @@
+# Copyright 2020 Paul Sitoh
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang:1.13.3
+
+WORKDIR /opt
+
+COPY ./cmd ./cmd
+COPY ./internal ./internal
+
+COPY ./go.mod ./go.mod
+COPY ./go.sum ./go.sum
+
+RUN go mod download && \
+    go test -v hls-devkit/hlsadmin/internal/usermgmt && \
+    go test -v hls-devkit/hlsadmin/cmd/hlsadmin/cli

--- a/build/package/test/unit/react.dockerfile
+++ b/build/package/test/unit/react.dockerfile
@@ -1,0 +1,26 @@
+# Copyright 2020 Paul Sitoh
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM node:13.10.1
+
+WORKDIR /opt
+
+COPY ./web/reactjs/package-lock.json /opt/package-lock.json
+COPY ./web/reactjs/package.json /opt/package.json
+COPY ./web/reactjs/webpack /opt/webpack
+COPY ./web/reactjs/.babelrc /opt/.babelrc
+COPY ./web/reactjs/images /opt/images
+COPY ./web/reactjs/src /opt/src
+
+RUN npm install && npm audit fix && npm test

--- a/deployments/e2e/docker-compose.yaml
+++ b/deployments/e2e/docker-compose.yaml
@@ -2,28 +2,14 @@ version: '3.4'
 
 services:
 
-    goreact:
+    hlsadmin:
         image: ${APP_IMAGE_NAME}:${APP_IMAGE_TAG}
-        container_name: goreact
+        container_name: hlsadmin
         command: ["/hlsadmin","start", "ui"]
         ports:
             - 80:80
         networks:
             - hlsadmin_e2e_network
-
-    # TODO: ADD database to mock your authentication server
-    # db:
-    #     image: ${DB_IMAGE_NAME}:${DB_IMAGE_TAG}
-    #     container_name: db
-    #     user: postgres
-    #     ports:
-    #         - 5432:5432
-    #     environment:
-    #         - POSTGRES_DB=goweb_db
-    #         - POSTGRES_PASSWORD=adminpw
-    #     working_dir: /opt
-    #     networks:
-    #         - hlsadmin_e2e_network
 
 networks:
     hlsadmin_e2e_network:

--- a/scripts/artefacts/build.sh
+++ b/scripts/artefacts/build.sh
@@ -19,7 +19,6 @@
 COMMAND="$1"
 
 native_build_image=hls_devkit/native_build_image:current
-test_build_image=hls_devkit/test_build_image:current
 
 function packageContainer() {
     docker build -f ./build/package/artefacts/Dockerfile -t ${APP_IMAGE_NAME}:${APP_IMAGE_TAG} .
@@ -40,10 +39,6 @@ function packageNative(){
     docker rmi -f ${native_build_image}
 }
 
-function goUnitTest(){
-    docker build -f ./build/package/artefacts/Dockerfile --target gotest -t ${test_build_image} .
-}
-
 function cleanNative() {
     if [ -d ./build/native ]; then
         rm -rf ./build/native
@@ -52,7 +47,6 @@ function cleanNative() {
 
 function cleanImages() {
     docker rmi -f ${APP_IMAGE_NAME}:${APP_IMAGE_TAG}
-    docker rmi -f ${test_build_image}
     docker rmi -f $(docker images --filter "dangling=true" -q)
 }
 
@@ -61,14 +55,11 @@ case $COMMAND in
         packageNative
         packageContainer
         ;;
-    "unit")
-        goUnitTest
-        ;;
     "clean")
         cleanNative
         cleanImages
         ;;
     *)
-        echo "$0 [ package | unit | clean ]"
+        echo "$0 [ package | clean ]"
         ;;
 esac

--- a/scripts/test/e2e.sh
+++ b/scripts/test/e2e.sh
@@ -18,9 +18,6 @@
 
 COMMAND="$1"
 
-export DB_IMAGE_NAME=postgres
-export DB_IMAGE_TAG=12
-
 function start(){
     docker-compose -f ./deployments/e2e/docker-compose.yaml up -d
 }

--- a/scripts/test/unit.sh
+++ b/scripts/test/unit.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Copyright 2020 Paul Sitoh
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+COMMAND="$1"
+
+go_unit_test_image=hls_devkit/go_unit_test_image:current
+react_unit_test_image=hls_devkit/react_unit_test_image:current
+
+case $COMMAND in
+    "go")
+        docker build -f ./build/package/test/unit/go.dockerfile -t ${go_unit_test_image} .
+        ;;
+    "react")
+        docker build -f ./build/package/test/unit/react.dockerfile -t ${react_unit_test_image} .
+        ;;
+    "clean")
+        docker rmi -f ${react_unit_test_image}
+        docker rmi -f ${go_unit_test_image}
+        docker rmi -f $(docker images --filter "dangling=true" -q)
+        ;;
+    *)
+        echo "$0 [ go | react ]"
+        ;;
+esac

--- a/web/reactjs/package.json
+++ b/web/reactjs/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "webpack --config ./webpack/webpack.prod.js",
+    "test": "echo echo \"Test specification to be defined\"",
     "dev:build": "webpack --config ./webpack/webpack.dev.js",
     "dev:run": "npm run dev:build && webpack-dev-server --config ./webpack/webpack.dev.js"
   },


### PR DESCRIPTION
Currently, there is one big massive docker file combining the building
of artefacts and unit testing. This is divided out reduce the size of
the Dockerfile

Signed-off-by: Paul Sitoh <paulwizviz@gmail.com>