### PR TITLE
Make command builders private

### DIFF
--- a/cmd/hlsadmin/cli/noui.go
+++ b/cmd/hlsadmin/cli/noui.go
@@ -24,12 +24,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type NoUICmdBuilder struct {
+type noUICmdBuilder struct {
 	port    int
 	service func()
 }
 
-func (s *NoUICmdBuilder) cli() *cobra.Command {
+func (s *noUICmdBuilder) cli() *cobra.Command {
 	return &cobra.Command{
 		Use:   "noui",
 		Short: "application starts only with RESTFul endpoints",
@@ -39,15 +39,15 @@ func (s *NoUICmdBuilder) cli() *cobra.Command {
 	}
 }
 
-var noUICmdBuilder = NoUICmdBuilder{
+var noUICmdBlder = noUICmdBuilder{
 	port: 8080,
 }
 
 func init() {
-	noUICmdBuilder.service = func() {
+	noUICmdBlder.service = func() {
 		router := mux.NewRouter()
 		server.RESTRun(router)
-		log.Printf("Starting with no UI on port %v", noUICmdBuilder.port)
-		log.Fatal(http.ListenAndServe(fmt.Sprintf("0.0.0.0:%v", noUICmdBuilder.port), router))
+		log.Printf("Starting with no UI on port %v", noUICmdBlder.port)
+		log.Fatal(http.ListenAndServe(fmt.Sprintf("0.0.0.0:%v", noUICmdBlder.port), router))
 	}
 }

--- a/cmd/hlsadmin/cli/noui_test.go
+++ b/cmd/hlsadmin/cli/noui_test.go
@@ -17,7 +17,7 @@ package cli
 import "testing"
 
 func TestNoUICmdName(t *testing.T) {
-	builder := NoUICmdBuilder{}
+	builder := noUICmdBuilder{}
 	builder.service = func() {}
 
 	cmd := builder.cli()
@@ -29,7 +29,7 @@ func TestNoUICmdName(t *testing.T) {
 }
 
 func TestNoUICmdPortFlag(t *testing.T) {
-	builder := NoUICmdBuilder{
+	builder := noUICmdBuilder{
 		port: 8080,
 	}
 	builder.service = func() {

--- a/cmd/hlsadmin/cli/start.go
+++ b/cmd/hlsadmin/cli/start.go
@@ -24,11 +24,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type StartCmdBuilder struct {
+type startCmdBuilder struct {
 	initapp func() (string, error)
 }
 
-func (s *StartCmdBuilder) cli() *cobra.Command {
+func (s *startCmdBuilder) cli() *cobra.Command {
 	return &cobra.Command{
 		Use:   "start",
 		Short: "choice of features",
@@ -42,11 +42,11 @@ func (s *StartCmdBuilder) cli() *cobra.Command {
 	}
 }
 
-var startCmdBuilder = StartCmdBuilder{}
+var startCmdBlder = startCmdBuilder{}
 
 func init() {
 
-	startCmdBuilder.initapp = func() (string, error) {
+	startCmdBlder.initapp = func() (string, error) {
 		home, err := os.UserHomeDir()
 		if err != nil {
 			return "", err
@@ -63,15 +63,15 @@ func init() {
 
 func initStartCmd() *cobra.Command {
 
-	startCmd := startCmdBuilder.cli()
+	startCmd := startCmdBlder.cli()
 
-	uiCmd := uiCmdBuilder.cli()
+	uiCmd := uiCmdBlder.cli()
 	startCmd.AddCommand(uiCmd)
-	uiCmd.Flags().IntVarP(&uiCmdBuilder.port, "port", "p", 80, "startup default port 80")
+	uiCmd.Flags().IntVarP(&uiCmdBlder.port, "port", "p", 80, "startup default port 80")
 
-	noUICmd := noUICmdBuilder.cli()
+	noUICmd := noUICmdBlder.cli()
 	startCmd.AddCommand(noUICmd)
-	noUICmd.Flags().IntVarP(&noUICmdBuilder.port, "port", "p", 8080, "startup default port 8080")
+	noUICmd.Flags().IntVarP(&noUICmdBlder.port, "port", "p", 8080, "startup default port 8080")
 
 	return startCmd
 }

--- a/cmd/hlsadmin/cli/start_test.go
+++ b/cmd/hlsadmin/cli/start_test.go
@@ -18,7 +18,7 @@ import "testing"
 
 func TestStartCmdName(t *testing.T) {
 
-	builder := StartCmdBuilder{}
+	builder := startCmdBuilder{}
 	builder.initapp = func() (string, error) {
 		return "", nil
 	}

--- a/cmd/hlsadmin/cli/ui.go
+++ b/cmd/hlsadmin/cli/ui.go
@@ -24,12 +24,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type UICmdBuilder struct {
+type uiCmdBuilder struct {
 	port    int
 	service func()
 }
 
-func (s *UICmdBuilder) cli() *cobra.Command {
+func (s *uiCmdBuilder) cli() *cobra.Command {
 	return &cobra.Command{
 		Use:   "ui",
 		Short: "application with ui",
@@ -39,16 +39,16 @@ func (s *UICmdBuilder) cli() *cobra.Command {
 	}
 }
 
-var uiCmdBuilder = UICmdBuilder{
+var uiCmdBlder = uiCmdBuilder{
 	port: 80,
 }
 
 func init() {
-	uiCmdBuilder.service = func() {
+	uiCmdBlder.service = func() {
 		router := mux.NewRouter()
 		server.RESTRun(router)
 		server.WebRun(router)
-		log.Printf("Starting with UI on port %v", uiCmdBuilder.port)
-		log.Fatal(http.ListenAndServe(fmt.Sprintf("0.0.0.0:%v", uiCmdBuilder.port), router))
+		log.Printf("Starting with UI on port %v", uiCmdBlder.port)
+		log.Fatal(http.ListenAndServe(fmt.Sprintf("0.0.0.0:%v", uiCmdBlder.port), router))
 	}
 }

--- a/cmd/hlsadmin/cli/ui_test.go
+++ b/cmd/hlsadmin/cli/ui_test.go
@@ -17,7 +17,7 @@ package cli
 import "testing"
 
 func TestUICmdName(t *testing.T) {
-	builder := UICmdBuilder{}
+	builder := uiCmdBuilder{}
 	builder.service = func() {}
 
 	cmd := builder.cli()
@@ -29,7 +29,7 @@ func TestUICmdName(t *testing.T) {
 }
 
 func TestUICmdPortFlag(t *testing.T) {
-	builder := UICmdBuilder{
+	builder := uiCmdBuilder{
 		port: 80,
 	}
 	builder.service = func() {


### PR DESCRIPTION
These builders are currently public and could accidentally leaked out.
This changes are to make it private.

Signed-off-by: Paul Sitoh <paulwizviz@gmail.com>